### PR TITLE
Add A-D support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Above example generate DTMF tone relates to digit 3 for 100 milliseconds.
 
 Copyright (c) 2019 Dilshan R Jayakody.
 
+Minor changes - A-D support added David Pye
+
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

--- a/dtmfgen.cpp
+++ b/dtmfgen.cpp
@@ -74,7 +74,7 @@ DTMFGenerator::DTMFGenerator()
 void DTMFGenerator::generate(char key, unsigned long duration)
 {
   unsigned long timerCycle = 0;
-  // This library allows numerical characters, A-D, # and * only.
+  // This library supports valid DTMF characters (A-D, 0-9, *, #)
   // Distinguish the low-frequency and high-frequency components of the DTMF waveform.
   switch (key)
   {
@@ -148,7 +148,7 @@ void DTMFGenerator::generate(char key, unsigned long duration)
     break;
   default:
     // Unsupported character
-    return
+    return;
   }
 
   // Start waveform from VCC/2.

--- a/dtmfgen.cpp
+++ b/dtmfgen.cpp
@@ -1,48 +1,36 @@
 /* Copyright 2019 Dilshan R Jayakody.
- *
- * Permission is hereby granted, free of charge, to any person obtaining a 
- * copy of this software and associated documentation files (the "Software"), 
- * to deal in the Software without restriction, including without limitation 
- * the rights to use, copy, modify, merge, publish, distribute, sublicense, 
- * and/or sell copies of the Software, and to permit persons to whom the 
+ * A-D support added 2025 David Pye <davidmpye@gmail.com>
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
  *
- * The above copyright notice and this permission notice shall be included 
+ * The above copyright notice and this permission notice shall be included
  * in all copies or substantial portions of the Software.
  *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS 
- * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL 
- * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING 
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
 
 #include "Arduino.h"
 #include "dtmfgen.h"
 
-#define CHAR_ZERO   48
-#define CHAR_ONE    49
-#define CHAR_TWO    50
-#define CHAR_THREE  51
-#define CHAR_FOUR   52
-#define CHAR_FIVE   53
-#define CHAR_SIX    54
-#define CHAR_SEVEN  55
-#define CHAR_EIGHT  56
-#define CHAR_NINE   57
-#define CHAR_HASH   35
-#define CHAR_STAR   42
+#define ROW_697 14
+#define ROW_770 15
+#define ROW_852 17
+#define ROW_941 19
 
-#define ROW_697   14
-#define ROW_770   15
-#define ROW_852   17
-#define ROW_941   19
-
-#define COL_1209  24
-#define COL_1336  27
-#define COL_1477  30
+#define COL_1209 24
+#define COL_1336 27
+#define COL_1477 30
+#define COL_1633 33
 
 #define WAVE_TABLE_SIZE 200
 
@@ -54,21 +42,21 @@ unsigned char DTMFGenerator::dtmfColPos = 0;
 unsigned char DTMFGenerator::rowOffset = 0;
 unsigned char DTMFGenerator::colOffset = 0;
 
-unsigned char waveTable[WAVE_TABLE_SIZE] = { 
-   64,  66,  68,  69,  71,  73,  75,  77,  79,  80,  82,  84,  86,  88,  89, 
-   91,  93,  94,  96,  97,  99, 101, 102, 103, 105, 106, 107, 109, 110, 111, 
-  112, 113, 114, 115, 116, 117, 118, 119, 120, 120, 121, 121, 122, 122, 123, 
-  123, 123, 123, 124, 124, 124, 124, 124, 123, 123, 123, 123, 122, 122, 121, 
-  121, 120, 120, 119, 118, 117, 116, 115, 114, 113, 112, 111, 110, 109, 107, 
-  106, 105, 103, 102, 101,  99,  97,  96,  94,  93,  91,  89,  88,  86,  84, 
-   82,  80,  79,  77,  75,  73,  71,  69,  68,  66,  64,  62,  60,  58,  56, 
-   54,  53,  51,  49,  47,  45,  43,  42,  40,  38,  37,  35,  33,  32,  30, 
-   28,  27,  26,  24,  23,  21,  20,  19,  18,  16,  15,  14,  13,  12,  11, 
-   10,   9,   9,   8,   7,   7,   6,   6,   5,   5,   4,   4,   4,   4,   4, 
-   04,   4,   4,   4,   4,   4,   5,   5,   6,   6,   7,   7,   8,   9,   9, 
-   10,  11,  12,  13,  14,  15,  16,  18,  19,  20,  21,  23,  24,  26,  27, 
-   28,  30,  32,  33,  35,  37,  38,  40,  42,  43,  45,  47,  49,  51,  53, 
-   54,  56,  58,  60,  62 };
+unsigned char waveTable[WAVE_TABLE_SIZE] = {
+    64, 66, 68, 69, 71, 73, 75, 77, 79, 80, 82, 84, 86, 88, 89,
+    91, 93, 94, 96, 97, 99, 101, 102, 103, 105, 106, 107, 109, 110, 111,
+    112, 113, 114, 115, 116, 117, 118, 119, 120, 120, 121, 121, 122, 122, 123,
+    123, 123, 123, 124, 124, 124, 124, 124, 123, 123, 123, 123, 122, 122, 121,
+    121, 120, 120, 119, 118, 117, 116, 115, 114, 113, 112, 111, 110, 109, 107,
+    106, 105, 103, 102, 101, 99, 97, 96, 94, 93, 91, 89, 88, 86, 84,
+    82, 80, 79, 77, 75, 73, 71, 69, 68, 66, 64, 62, 60, 58, 56,
+    54, 53, 51, 49, 47, 45, 43, 42, 40, 38, 37, 35, 33, 32, 30,
+    28, 27, 26, 24, 23, 21, 20, 19, 18, 16, 15, 14, 13, 12, 11,
+    10, 9, 9, 8, 7, 7, 6, 6, 5, 5, 4, 4, 4, 4, 4,
+    04, 4, 4, 4, 4, 4, 5, 5, 6, 6, 7, 7, 8, 9, 9,
+    10, 11, 12, 13, 14, 15, 16, 18, 19, 20, 21, 23, 24, 26, 27,
+    28, 30, 32, 33, 35, 37, 38, 40, 42, 43, 45, 47, 49, 51, 53,
+    54, 56, 58, 60, 62};
 
 DTMFGenerator::DTMFGenerator()
 {
@@ -86,103 +74,122 @@ DTMFGenerator::DTMFGenerator()
 void DTMFGenerator::generate(char key, unsigned long duration)
 {
   unsigned long timerCycle = 0;
-  
-  // This library allows numerical characters, # and * only.
-  if(((key >= CHAR_ZERO) && (key <= CHAR_NINE)) || (key == CHAR_HASH) || (key == CHAR_STAR))
+  // This library allows numerical characters, A-D, # and * only.
+  // Distinguish the low-frequency and high-frequency components of the DTMF waveform.
+  switch (key)
   {
-    // Distinguish the low-frequency and high-frequency components of the DTMF waveform.
-    switch(key)
-    {
-      case CHAR_ONE:
-        rowOffset = ROW_697;
-        colOffset = COL_1209;
-        break;
-      case CHAR_TWO:
-        rowOffset = ROW_697;
-        colOffset = COL_1336;
-        break;
-      case CHAR_THREE:
-        rowOffset = ROW_697;
-        colOffset = COL_1477;
-        break;
-      case CHAR_FOUR:
-        rowOffset = ROW_770;
-        colOffset = COL_1209;
-        break;
-      case CHAR_FIVE:
-        rowOffset = ROW_770; 
-        colOffset = COL_1336;
-        break;
-      case CHAR_SIX:
-        rowOffset = ROW_770;
-        colOffset = COL_1477;
-        break;
-      case CHAR_SEVEN:
-        rowOffset = ROW_852;
-        colOffset = COL_1209;
-        break;
-      case CHAR_EIGHT:
-        rowOffset = ROW_852;
-        colOffset = COL_1336;
-        break;
-      case CHAR_NINE:
-        rowOffset = ROW_852;
-        colOffset = COL_1477;
-        break;
-      case CHAR_STAR:
-        rowOffset = ROW_941;
-        colOffset = COL_1209;
-        break;
-      case CHAR_ZERO:
-        rowOffset = ROW_941;
-        colOffset = COL_1336;
-        break;
-      case CHAR_HASH:
-        rowOffset = ROW_941;
-        colOffset = COL_1477;
-        break;
-    }
-
-    // Start waveform from VCC/2.
-    dtmfRowPos = 0;
-    dtmfColPos = 0;
-
-    // Start TIMER1 with frequency of 10KHz.
-    noInterrupts();
-
-    // Initialize TIMER1 registers to known state. 
-    TCCR1A = 0;
-    TCCR1B = 0;
-    TCNT1 = 0;
-    TIMSK1 = 0;
-
-    // Set TIMER1 to 10KHz with reference to 16MHz Arduino clock. 
-    OCR1A = 24;
-    TCCR1B |= (1 << WGM12);
-    TCCR1B |= (1 << CS11) | (1 << CS10);
-
-    // Enable TIMER1 interrupt.
-    TIMSK1 |= (1 << OCIE1A);
-    interrupts();
-
-    // Wait for specified duration.
-    while(timerCycle < duration)
-    {
-      timerCycle++;
-      delay(1);
-    }
-
-    // Disable TIMER1 interrupt and clear all TIMER1 associated registers.
-    noInterrupts();
-    TCCR1A = 0;
-    TCCR1B = 0;
-    TCNT1 = 0;
-    TIMSK1 = 0;
-    interrupts();
-    
-    // Reset DTMF output to VCC/2.
-    DTMF_PORT = waveTable[0] + waveTable[0];
+  case '1':
+    rowOffset = ROW_697;
+    colOffset = COL_1209;
+    break;
+  case '2':
+    rowOffset = ROW_697;
+    colOffset = COL_1336;
+    break;
+  case '3':
+    rowOffset = ROW_697;
+    colOffset = COL_1477;
+    break;
+  case '4':
+    rowOffset = ROW_770;
+    colOffset = COL_1209;
+    break;
+  case '5':
+    rowOffset = ROW_770;
+    colOffset = COL_1336;
+    break;
+  case '6':
+    rowOffset = ROW_770;
+    colOffset = COL_1477;
+    break;
+  case '7':
+    rowOffset = ROW_852;
+    colOffset = COL_1209;
+    break;
+  case '8':
+    rowOffset = ROW_852;
+    colOffset = COL_1336;
+    break;
+  case '9':
+    rowOffset = ROW_852;
+    colOffset = COL_1477;
+    break;
+  case '*':
+    rowOffset = ROW_941;
+    colOffset = COL_1209;
+    break;
+  case '0':
+    rowOffset = ROW_941;
+    colOffset = COL_1336;
+    break;
+  case '#':
+    rowOffset = ROW_941;
+    colOffset = COL_1477;
+    break;
+  case 'A':
+  case 'a':
+    rowOffset = ROW_697;
+    colOffset = COL_1633;
+    break;
+  case 'B':
+  case 'b':
+    rowOffset = ROW_770;
+    colOffset = COL_1633;
+    break;
+  case 'C':
+  case 'c':
+    rowOffset = ROW_852;
+    colOffset = COL_1633;
+    break;
+  case 'D':
+  case 'd':
+    rowOffset = ROW_941;
+    colOffset = COL_1633;
+    break;
+  default:
+    // Unsupported character
+    return
   }
+
+  // Start waveform from VCC/2.
+  dtmfRowPos = 0;
+  dtmfColPos = 0;
+
+  // Start TIMER1 with frequency of 10KHz.
+  noInterrupts();
+
+  // Initialize TIMER1 registers to known state.
+  TCCR1A = 0;
+  TCCR1B = 0;
+  TCNT1 = 0;
+  TIMSK1 = 0;
+
+  // Set TIMER1 to 10KHz with reference to 16MHz Arduino clock.
+  OCR1A = 24;
+  TCCR1B |= (1 << WGM12);
+  TCCR1B |= (1 << CS11) | (1 << CS10);
+
+  // Enable TIMER1 interrupt.
+  TIMSK1 |= (1 << OCIE1A);
+  interrupts();
+
+  // Wait for specified duration.
+  while (timerCycle < duration)
+  {
+    timerCycle++;
+    delay(1);
+  }
+
+  // Disable TIMER1 interrupt and clear all TIMER1 associated registers.
+  noInterrupts();
+  TCCR1A = 0;
+  TCCR1B = 0;
+  TCNT1 = 0;
+  TIMSK1 = 0;
+  interrupts();
+
+  // Reset DTMF output to VCC/2.
+  DTMF_PORT = waveTable[0] + waveTable[0];
 }
 
 void DTMFGenerator::waveGenerator()
@@ -194,13 +201,13 @@ void DTMFGenerator::waveGenerator()
   dtmfColPos += colOffset;
 
   // Check for end of low-frequency wave cycle.
-  if(dtmfRowPos >= WAVE_TABLE_SIZE)
+  if (dtmfRowPos >= WAVE_TABLE_SIZE)
   {
     dtmfRowPos -= WAVE_TABLE_SIZE;
   }
 
   // Check for end of high-frequency wave cycle.
-  if(dtmfColPos >= WAVE_TABLE_SIZE)
+  if (dtmfColPos >= WAVE_TABLE_SIZE)
   {
     dtmfColPos -= WAVE_TABLE_SIZE;
   }
@@ -208,7 +215,7 @@ void DTMFGenerator::waveGenerator()
 
 void DTMFGenerator::generateOutput()
 {
-  if(generatorInstance != NULL)
+  if (generatorInstance != NULL)
   {
     generatorInstance->waveGenerator();
   }

--- a/dtmfgen.h
+++ b/dtmfgen.h
@@ -23,7 +23,7 @@
 #define DTMF_GENERATOR_H
 
 #if !defined(__AVR_ATmega328P__)
-  #error Unsupported board. This library support ATmega328P based Arduino Uno boards only.	
+  #error Unsupported board. This library supports ATmega328P based Arduino Uno boards only.	
 #endif
 
 class DTMFGenerator


### PR DESCRIPTION
Hi,

Thanks for your excellent work on the DTMGEN library.

While making a Rust port for Pi Pico, I noticed that you didn't currently have support for the A-D control characters, which are occasionally useful for things like amateur radio signalling.

I've taken the liberty of making a pull request which adds the control characters.

Most of the rest of the apparent changes are removal of trailing whitespace, and removal of some char #defines.

Hopefully it may be of use :-)

Kind regards,

David